### PR TITLE
Testing PR: Add validation for invalid counter names

### DIFF
--- a/ci_lab/CI/tests/test_counter.py
+++ b/ci_lab/CI/tests/test_counter.py
@@ -273,10 +273,11 @@ class TestCounterEndpoints:
     def test_validate_counter_name(self, client):
         """It should prevent creating counters with special characters"""
         response = client.post('/counters/test@123')
-
         assert response.status_code == HTTPStatus.BAD_REQUEST
 
-        # TODO: Add an assertion to verify the error message specifically says 'Invalid counter name'S
+        # Check the error message in the JSON response - Brian
+        data = response.get_json()
+        assert data["error"] == "Invalid counter name. Only alphanumeric and underscores allowed."
 
     # One new test that I authored
     def test_dummy_for_pipeline(self):


### PR DESCRIPTION
### Description
This PR fulfills the Testing PR requirement. I added an assertion to `test_validate_counter_name` to verify that the API returns the exact error message `"Invalid counter name. Only alphanumeric and underscores allowed."` when special characters are used.

**Resolves Issue:** #38

### Coverage
Before adding the test assertion, coverage was at 89%. After adding the test, it remains at 89%, but the specific edge case for bad input is now successfully asserted and verified.